### PR TITLE
Introduce RT5350 basic support

### DIFF
--- a/sys/conf/options.mips
+++ b/sys/conf/options.mips
@@ -127,6 +127,7 @@ MT7620				opt_rt305x.h
 RT5350				opt_rt305x.h
 RT305XF				opt_rt305x.h
 RT3052F				opt_rt305x.h
+RT3050F				opt_rt305x.h
 RT305X				opt_rt305x.h
 RT305X_UBOOT			opt_rt305x.h
 RT305X_USE_UART			opt_rt305x.h

--- a/sys/mips/conf/RT305X
+++ b/sys/mips/conf/RT305X
@@ -34,6 +34,7 @@ hints		"RT305X.hints"		#Default places to look for devices.
 #makeoptions	DEBUG=-g		#Build kernel with gdb(1) debug symbols
 
 options		RT3052F
+options		RT305X_UBOOT
 
 # Debugging for use in -current
 #options 	DEADLKRES		#Enable the deadlock resolver

--- a/sys/mips/conf/RT5350
+++ b/sys/mips/conf/RT5350
@@ -1,4 +1,4 @@
-# MT7620 -- Kernel configuration file for FreeBSD/mips for Ralink MT7620 systems
+# RT5350 -- Kernel configuration file for FreeBSD/mips for Ralink RT5350 systems
 #
 # For more information on this file, please read the handbook section on
 # Kernel Configuration Files:
@@ -17,24 +17,23 @@
 #
 # $FreeBSD$
 
-ident		MT7620
+ident		RT5350
 
 machine		mips mipsel
 makeoptions	MIPS_LITTLE_ENDIAN=defined
 makeoptions	KERNLOADADDR=0x80001000
 
 # Don't build any modules yet.
-#makeoptions	MODULES_OVERRIDE="wlan_xauth wlan_wep wlan_tkip wlan_acl wlan_amrr wlan_ccmp wlan_rssadapt if_bridge bridgestp msdosfs md ipfw dummynet libalias geom/geom_label ufs usb/uplcom usb/u3g usb/umodem usb/umass usb/ucom cam zlib"
-makeoptions	MODULES_OVERRIDE=""
-makeoptions	MT7620
+makeoptions	MODULES_OVERRIDE="wlan_xauth wlan_wep wlan_tkip wlan_acl wlan_amrr wlan_ccmp wlan_rssadapt if_bridge bridgestp msdosfs md ipfw dummynet libalias geom/geom_label ufs usb/uplcom usb/u3g usb/umodem usb/umass usb/ucom cam zlib"
+makeoptions	RT5350
 
 include		"../rt305x/std.rt305x"
 
-hints		"MT7620.hints"		#Default places to look for devices.
+hints		"RT5350.hints"		#Default places to look for devices.
 
 #makeoptions	DEBUG=-g		#Build kernel with gdb(1) debug symbols
 
-options		MT7620
+options		RT5350
 options		RT305X_UBOOT
 
 # Debugging for use in -current
@@ -51,99 +50,76 @@ options 	DDB
 options 	KDB
 
 options 	SCHED_ULE
-#options 	SCHED_4BSD		#4BSD scheduler
-#options 	COMPAT_43
 options 	INET			#InterNETworking
-options 	NFSCL			#Network Filesystem Client
-options 	NFS_ROOT		#NFS usable as /, requires NFSCL
+#options 	NFSCL			#Network Filesystem Client
+#options 	NFS_ROOT		#NFS usable as /, requires NFSCL
 options 	PSEUDOFS		#Pseudo-filesystem framework
 #options 	_KPOSIX_PRIORITY_SCHEDULING #Posix P1003_1B real-time extensions
 
-#options 	BOOTP
-#options 	BOOTP_NFSROOT
-#options 	BOOTP_NFSV3
-#options 	BOOTP_WIRED_TO=rt0
-#options 	BOOTP_COMPAT
-#options 	CD9660			# ISO 9660 Filesystem
-#options 	ROOTDEVNAME=\"cd9660:/dev/map/rootfs.uncompress\"
-#options 	TMPFS			# TMP Memory Filesystem
+#options		BOOTP
+#options		BOOTP_NFSROOT
+#options		BOOTP_NFSV3
+#options		BOOTP_WIRED_TO=rt0
+#options		BOOTP_COMPAT
+
+options 	TMPFS			# TMP Memory Filesystem
 
 options 	FFS			#Berkeley Fast Filesystem
-#options 	SOFTUPDATES		#Enable FFS soft updates support
-#options 	UFS_ACL			#Support for access control lists
-#options 	UFS_DIRHASH		#Improve performance on big directories
-#options 	ROOTDEVNAME=\"nfs:10.0.0.1:/mnt/bsd\"
+#options		ROOTDEVNAME=\"nfs:193.178.153.200:/bsdmips\"
+
+#device		geom_uncompress
+#options		GEOM_UNCOMPRESS
+#options		MD_ROOT
+#options		ROOTDEVNAME=\"ufs:md0.uncompress\"
 
 # Options for making kernel less hangry
-#makeoptions	INLINE_LIMIT=1024
-#options 	MAXUSERS=3
-#options 	MAXFILES=512
-#options 	NSFBUFS=256
-#options 	SHMALL=128
-#options 	MSGBUF_SIZE=65536
+makeoptions	INLINE_LIMIT=1024
+options 	MAXUSERS=3
+options 	MAXFILES=512
+options 	NSFBUFS=256
+options 	SHMALL=128
+options 	MSGBUF_SIZE=65536
 
 # Options for making kernel smallest 
-#options 	NO_SYSCTL_DESCR		# No description string of sysctl
+options 	NO_SYSCTL_DESCR		# No description string of sysctl
 #options 	NO_FFS_SNAPSHOT		# Disable Snapshot supporting
-#options 	SCSI_NO_SENSE_STRINGS
-#options 	SCSI_NO_OP_STRINGS
-#options 	RWLOCK_NOINLINE
-#options 	SX_NOINLINE
-#options 	NO_SWAPPING
+options 	SCSI_NO_SENSE_STRINGS
+options 	SCSI_NO_OP_STRINGS
+options 	RWLOCK_NOINLINE
+options 	SX_NOINLINE
+options 	NO_SWAPPING
 options         MROUTING                # Multicast routing
 options 	IPFIREWALL_DEFAULT_TO_ACCEPT
 
-options		GEOM_UNCOMPRESS
-options		MD_ROOT
-options		ROOTDEVNAME=\"ufs:da0s1\"
-
-device		md
-
+#device		md
 device		random
 device		loop
 # RT3050F, RT3052F have only pseudo PHYs, so mii not required
 device		rt
 
-device		spibus
-device		mx25l
-
 device		ether
-device		miibus
 device 		bpf			# Berkeley packet filter
 device		vlan
-device		lagg
-device          if_bridge
+#device		lagg
+#device          if_bridge
 device		uart
 nodevice	uart_ns8250
-#device 		tun			# Packet tunnel.
+device 		tun			# Packet tunnel.
 
-#device		wlan
-
+device		wlan
 
 #device		gpio
 #device		gpioled
 
-#device		cfi			# Detect Flash memmory
-#device		cfid
-
 #device		nvram2env
+
+device		spibus
+device		mx25l
 
 device		usb
 device		ehci
-#device		ohci
-#device		dwcotg			# DWC like USB OTG Controller driver
-#device		u3g
-#device		umodem
-#device		uplcom
-device		cdce
-device		umass
-device		da
-device		pass
-device		scbus
 options 	SCSI_DELAY=1000		# Delay (in ms) before probing SCSI
 
 #options 	USB_EHCI_BIG_ENDIAN_DESC        # handle big-endian byte order
 #options 	USB_DEBUG
 #options 	USB_REQ_DEBUG
-
-device		pci

--- a/sys/mips/conf/RT5350.hints
+++ b/sys/mips/conf/RT5350.hints
@@ -1,0 +1,35 @@
+# $FreeBSD$
+# device.hints
+hint.obio.0.at="nexus0"
+hint.obio.0.maddr=0x10000000
+hint.obio.0.msize=0x10000000
+
+hint.mx25l.0.at="spibus0"
+
+#hint.nvram.0.sig=0xe5e60a74
+#hint.nvram.0.base=0x1f030000
+#hint.nvram.0.maxsize=0x2000
+#hint.nvram.0.flags=3 # 1 = No check, 2 = Format Generic
+#hint.nvram.1.sig=0x5a045e94
+#hint.nvram.1.base=0x1f032000
+#hint.nvram.1.maxsize=0x4000
+#hint.nvram.1.flags=3 # 1 = No check, 2 = Format Generic
+
+# on-board Ralink Frame Engine
+hint.rt.0.at="nexus0"
+hint.rt.0.maddr=0x10100000
+hint.rt.0.msize=0x10000
+hint.rt.0.irq=3
+# macaddr can be statically set
+#hint.rt.0.macaddr="xx:xx:xx:xx:xx:xx"
+
+# on-board Ralink 2872 802.11n core
+hint.rt2860.0.at="nexus0"
+hint.rt2860.0.maddr=0x10180000
+hint.rt2860.0.msize=0x40000
+hint.rt2860.0.irq=4
+
+hint.rt.0.phymask=0x1f
+hint.rt.0.media=100
+hint.rt.0.fduplex=1
+

--- a/sys/mips/rt305x/obio.c
+++ b/sys/mips/rt305x/obio.c
@@ -248,10 +248,10 @@ obio_attach(device_t dev)
 	obio_add_res_child(dev, "uart", 1,
 	    UARTLITE_BASE, (UARTLITE_END - UARTLITE_BASE + 1),
 	    IC_UARTLITE);
+#if !defined(RT5350) && !defined(MT7620)
 	obio_add_res_child(dev, "cfi", 	0,
 	    FLASH_BASE, (FLASH_END - FLASH_BASE  + 1),
 	    -1);
-#ifndef MT7620
 	obio_add_res_child(dev, "dwcotg", 0,
 	    USB_OTG_BASE, (USB_OTG_END - USB_OTG_BASE  + 1),
 	    IC_OTG);

--- a/sys/mips/rt305x/rt305x_ehci.c
+++ b/sys/mips/rt305x/rt305x_ehci.c
@@ -92,7 +92,10 @@ ehci_obio_attach(device_t self)
 	rt305x_sysctl_set(SYSCTL_SYSCFG1, reg);
 
 	reg = rt305x_sysctl_get(SYSCTL_CLKCFG1);
-	reg |= SYSCTL_CLKCFG1_UPHY0_CLK_EN | SYSCTL_CLKCFG1_UPHY1_CLK_EN;
+	reg |= SYSCTL_CLKCFG1_UPHY0_CLK_EN;
+#ifdef MT7620
+	reg |= SYSCTL_CLKCFG1_UPHY1_CLK_EN;
+#endif
 	rt305x_sysctl_set(SYSCTL_CLKCFG1, reg);
 
 	reg = rt305x_sysctl_get(SYSCTL_RSTCTRL);
@@ -192,7 +195,11 @@ ehci_obio_detach(device_t self)
 		/* Stop EHCI clock */
 		rt305x_sysctl_set(SYSCTL_CLKCFG1, 
 		  rt305x_sysctl_get(SYSCTL_CLKCFG1) & 
-		  ~(SYSCTL_CLKCFG1_UPHY0_CLK_EN | SYSCTL_CLKCFG1_UPHY1_CLK_EN));
+		  ~(SYSCTL_CLKCFG1_UPHY0_CLK_EN
+#ifdef MT7620
+		    | SYSCTL_CLKCFG1_UPHY1_CLK_EN
+#endif
+		));
 
 		err = bus_teardown_intr(self, sc->sc_irq_res, sc->sc_intr_hdl);
 		if (err)

--- a/sys/mips/rt305x/rt305x_machdep.c
+++ b/sys/mips/rt305x/rt305x_machdep.c
@@ -71,6 +71,7 @@ __FBSDID("$FreeBSD$");
 #include <machine/vmparam.h>
 
 #include <mips/rt305x/rt305xreg.h>
+#include <mips/rt305x/rt305x_sysctlvar.h>
 
 extern int	*edata;
 extern int	*end;
@@ -126,11 +127,11 @@ void
 platform_reset(void)
 {
 
-#ifndef MT7620
+#if !defined(MT7620) && !defined(RT5350)
 	__asm __volatile("li	$25, 0xbf000000");
 	__asm __volatile("j	$25");
 #else
-	*((volatile uint32_t *)0xb0000034) = 1;
+	rt305x_sysctl_set(SYSCTL_RSTCTRL, 1);
 	while (1);
 #endif
 }
@@ -154,6 +155,8 @@ platform_start(__register_t a0 __unused, __register_t a1 __unused,
 
 	/* Initialize pcpu stuff */
 	mips_pcpu0_init();
+
+	mips_timer_early_init(platform_counter_freq / 2);
 
 	/* initialize console so that we have printf */
 	boothowto |= (RB_SERIAL | RB_MULTIPLE);	/* Use multiple consoles */

--- a/sys/mips/rt305x/rt305x_ohci.c
+++ b/sys/mips/rt305x/rt305x_ohci.c
@@ -92,7 +92,10 @@ ohci_obio_attach(device_t self)
 	rt305x_sysctl_set(SYSCTL_SYSCFG1, reg);
 
 	reg = rt305x_sysctl_get(SYSCTL_CLKCFG1);
-	reg |= SYSCTL_CLKCFG1_UPHY0_CLK_EN | SYSCTL_CLKCFG1_UPHY1_CLK_EN;
+	reg |= SYSCTL_CLKCFG1_UPHY0_CLK_EN;
+#ifdef MT7620
+	reg |= SYSCTL_CLKCFG1_UPHY1_CLK_EN;
+#endif
 	rt305x_sysctl_set(SYSCTL_CLKCFG1, reg);
 
 	reg = rt305x_sysctl_get(SYSCTL_RSTCTRL);
@@ -192,7 +195,11 @@ ohci_obio_detach(device_t self)
 		/* Stop OHCI clock */
 		rt305x_sysctl_set(SYSCTL_CLKCFG1, 
 		  rt305x_sysctl_get(SYSCTL_CLKCFG1) & 
-		  ~(SYSCTL_CLKCFG1_UPHY0_CLK_EN | SYSCTL_CLKCFG1_UPHY1_CLK_EN));
+		  ~(SYSCTL_CLKCFG1_UPHY0_CLK_EN
+#ifdef MT7620
+		    | SYSCTL_CLKCFG1_UPHY1_CLK_EN
+#endif
+		));
 
 		err = bus_teardown_intr(self, sc->sc_irq_res, sc->sc_intr_hdl);
 		if (err)

--- a/sys/mips/rt305x/rt305x_sysctl.c
+++ b/sys/mips/rt305x/rt305x_sysctl.c
@@ -70,6 +70,7 @@ rt305x_sysctl_dump_config(device_t dev)
 	    (val >> 24) & 0xff);
 
 	DUMPREG(SYSCTL_SYSCFG);
+#if !defined(RT5350) && !defined(MT7620)
 	if ( val & SYSCTL_SYSCFG_INIC_EE_SDRAM)
 		printf("\tGet SDRAM config from EEPROM\n");
 	if ( val & SYSCTL_SYSCFG_INIC_8MB_SDRAM)
@@ -123,6 +124,7 @@ rt305x_sysctl_dump_config(device_t dev)
 	    ((val & SYSCTL_CLKCFG1_PCM_CLK_DIV_MASK) >> 
 		SYSCTL_CLKCFG1_PCM_CLK_DIV_SHIFT));
 	DUMPREG(SYSCTL_GPIOMODE);
+#endif
 #undef DUMPREG
 
 	return;

--- a/sys/mips/rt305x/rt305xreg.h
+++ b/sys/mips/rt305x/rt305xreg.h
@@ -41,6 +41,9 @@
 #ifdef MT7620
 #define PLATFORM_COUNTER_FREQ	(580 * 1000 * 1000)
 #endif
+#ifdef RT5350
+#define PLATFORM_COUNTER_FREQ	(360 * 1000 * 1000)
+#endif
 #ifndef PLATFORM_COUNTER_FREQ
 #error "No platform selected"
 #endif
@@ -60,16 +63,26 @@
 #define INTCTL_END 	0x100002FF
 #define MEMCTRL_BASE	0x10000300
 #define MEMCTRL_END 	0x100003FF /* SDRAM & Flash/SRAM */
+#ifndef RT5350
 #define PCM_BASE 	0x10000400
 #define PCM_END 	0x100004FF
+#else
+#define PCM_BASE	0x10002000
+#define PCM_END		0x100027FF
+#endif
 #define UART_BASE 	0x10000500
 #define UART_END 	0x100005FF
 #define PIO_BASE 	0x10000600
 #define PIO_END 	0x100006FF
+#ifndef RT5350
 #define GDMA_BASE 	0x10000700
 #define GDMA_END 	0x100007FF /* Generic DMA */
 #define NANDFC_BASE 	0x10000800
 #define NANDFC_END 	0x100008FF /* NAND Flash Controller */
+#else
+#define GDMA_BASE	0x10002800
+#define GDMA_END	0x10002FFF
+#endif
 #define I2C_BASE 	0x10000900
 #define I2C_END 	0x100009FF
 #define I2S_BASE 	0x10000A00
@@ -87,16 +100,33 @@
 #define ROM_END 	0x10119FFF
 #define WLAN_BASE 	0x10180000
 #define WLAN_END 	0x101BFFFF /* 802.11n MAC/BBP */
+#ifndef RT5350
 #define USB_OTG_BASE	0x101C0000
 #define USB_OTG_END 	0x101FFFFF
+#else
+#define USB_OTG_BASE	0x101C0000
+#define USB_OTG_END	0x101C0FFF
+#define USB_OHCI_BASE	0x101C1000
+#define USB_OHCI_END	0x101C1FFF
+#endif
 #define EMEM_BASE 	0x1B000000
 #define EMEM_END 	0x1BFFFFFF /* External SRAM/Flash */
+#ifdef RT5350
+#define BOOT_ROM_BASE	0x1C000000
+#define BOOT_ROM_END	0x1C003FFF
+#endif
+#ifndef RT5350
 #define FLASH_BASE 	0x1F000000
 #define FLASH_END 	0x1FFFFFFF /* Flash window */
+#endif
 
 #define OBIO_MEM_BASE	SYSCTL_BASE
 #define OBIO_MEM_START	OBIO_MEM_BASE
+#ifndef RT5350
 #define OBIO_MEM_END	FLASH_END
+#else
+#define OBIO_MEM_END	BOOT_ROM_END
+#endif
 
 #else /* MT7620 */
 
@@ -166,9 +196,14 @@
 #endif
 
 /* System Control */
-#define SYSCTL_CHIPID0_3 	0x00 /* 'R''T''3''0' */
-#define SYSCTL_CHIPID4_7 	0x04 /* '5''2'' '' ' */
+#define SYSCTL_CHIPID0_3 	0x00
+#define SYSCTL_CHIPID4_7 	0x04
+#ifdef RT5350
+#define SYSCTL_REVID		0x0C
+#endif
+
 #define SYSCTL_SYSCFG		0x10
+#if !defined(RT5350) && !defined(MT7620)
 #define SYSCTL_SYSCFG_INIC_EE_SDRAM		(1<<29)
 #define SYSCTL_SYSCFG_INIC_8MB_SDRAM		(1<<28) 
 #define SYSCTL_SYSCFG_GE0_MODE_MASK		0x03000000
@@ -194,6 +229,15 @@
 #define SYSCTL_SYSCFG_SRAM_CS_MODE_WDOG_RST	1
 #define SYSCTL_SYSCFG_SRAM_CS_MODE_BT_COEX	2
 #define SYSCTL_SYSCFG_SDRAM_CLK_DRV		(1<<0) /* 8mA/12mA */
+#endif
+#ifdef RT5350
+#define SYSCTL1_SYSCFG_PULL_EN			(1<<26)
+#define SYSCTL1_SYSCFG_SDR_PAD_DRV_MASK		0x0700000
+#define SYSCTL1_SYSCFG_SDR_PAD_DRV_SHIFT	20
+#define SYSCTL1_SYSCFG_SDR_PAD_DRV_0		0
+#define SYSCTL1_SYSCFG_SDR_PAD_DRV_1		1
+#define SYSCTL1_SYSCFG_SDR_PAD_DRV_2		2
+#endif
 
 #define SYSCTL_SYSCFG1		0x14
 #define SYSCTL_SYSCFG1_USB0_HOST_MODE		(1 << 10)
@@ -210,6 +254,7 @@
 #define SYSCTL_CLKCFG0_SDRAM_CLK_SKEW_3NS_DELAY		3
 
 #define SYSCTL_CLKCFG1		0x30
+#if !defined(RT5350)
 #define SYSCTL_CLKCFG1_PBUS_DIV_CLK_BY2		(1<<30)
 #define SYSCTL_CLKCFG1_UPHY0_CLK_EN		(1<<25)
 #define SYSCTL_CLKCFG1_UPHY1_CLK_EN		(1<<22)
@@ -222,10 +267,16 @@
 #define SYSCTL_CLKCFG1_PCM_CLK_SEL_EXT 		(1<<6)
 #define SYSCTL_CLKCFG1_PCM_CLK_DIV_MASK 		0x0000003f
 #define SYSCTL_CLKCFG1_PCM_CLK_DIV_SHIFT 	0
+#endif
+#ifdef RT5350
+#define SYSCTL_CLKCFG1_SYSTICK_EN		(1<<29)
+#define SYSCTL_CLKCFG1_PDMA_CSR_CLK_GATE_BYP	(1<<23)
+#define SYSCTL_CLKCFG1_UPHY0_CLK_EN		(1<<18)
+#endif
 
 #define SYSCTL_RSTCTRL		0x34
 #define SYSCTL_RSTCTRL_ETHSW		(1<<23)
-#ifndef MT7620
+#if !defined(MT7620) && !defined(RT5350)
 #define SYSCTL_RSTCTRL_OTG		(1<<22)
 #else
 #define SYSCTL_RSTCTRL_UPHY0		(1<<25)


### PR DESCRIPTION
- Introduce RT5350 basic support (no GPIO yet);
- Cleanup RT305X and MT7620 support.

Tested on RT5350, MT7620 and RT3050 and no obvious problems seen, apart from the fact that if_rt doesn't recover from down/up on MT7620 and RT5350 (couldn't test the same for RT3050 as my filesystem was on NFS).